### PR TITLE
Display basic summoner information

### DIFF
--- a/Controllers/SummonerController.cs
+++ b/Controllers/SummonerController.cs
@@ -1,13 +1,23 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Encodings.Web;
+using TftTracker.Data;
 
 namespace TftTracker.Controllers
 {
     public class SummonerController : Controller
     {
+        private readonly TftContext _context;
+
+        public SummonerController(TftContext context)
+        {
+            _context = context;
+        }
+
         public IActionResult Index()
         {
-            return View();
+            var results = _context.Summoners.OrderBy(summoner => summoner.id).ToList();
+
+            return View(results);
         }
     }
 }

--- a/Data/TftSeeder.cs
+++ b/Data/TftSeeder.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+using TftTracker.Data.Entities;
+
+namespace TftTracker.Data
+{
+    public class TftSeeder
+    {
+        private readonly TftContext _context;
+        private readonly IWebHostEnvironment _environment;
+
+        public TftSeeder(TftContext context, IWebHostEnvironment environment)
+        {
+            _context = context;
+            _environment = environment;
+        }
+
+        public void Seed()
+        {
+            //Make sure DB exists
+            _context.Database.EnsureCreated();
+
+            if (!_context.Summoners.Any())
+            {
+                //Create sample data
+                var filePath = Path.Combine(_environment.ContentRootPath, "Data/summoners.json");
+                var json = File.ReadAllText(filePath);
+                var summoners = JsonSerializer.Deserialize<IEnumerable<Summoner>>(json);
+
+                _context.Summoners.AddRange(summoners);
+                _context.SaveChanges();
+            }
+        }
+    }
+}

--- a/Data/summoners.json
+++ b/Data/summoners.json
@@ -1,0 +1,47 @@
+[
+    {
+    "accountId": "001",
+    "profileIconId": 1,
+    "revisionDate": 1637336253,
+    "name": "Vontell",
+    "id": "001",
+    "puuid": "223966216255869698397905954902832795240404252593253922975338362032908148800408",
+    "summonerLevel": 162
+  },
+  {
+    "accountId": "002",
+    "profileIconId": 2,
+    "revisionDate": 1637422653,
+    "name": "Noamit",
+    "id": "002",
+    "puuid": "334593073194552560377406391315206530355033163841091350809301025445228966072860",
+    "summonerLevel": 246
+  },
+  {
+    "accountId": "003",
+    "profileIconId": 3,
+    "revisionDate": 1637595453,
+    "name": "Elderhide",
+    "id": "003",
+    "puuid": "195111894475779608026284291654379250725617682730593568767939056016018336320484",
+    "summonerLevel": 77
+  },
+  {
+    "accountId": "004",
+    "profileIconId": 4,
+    "revisionDate": 1637681853,
+    "name": "Teemo Bot",
+    "id": "004",
+    "puuid": "897926350420425281935752938630402765267895217933423546578213631820283390490146",
+    "summonerLevel": 288
+  },
+  {
+    "accountId": "420",
+    "profileIconId": 420,
+    "revisionDate": 1637509420,
+    "name": "Ganjasaurus",
+    "id": "420",
+    "puuid": "420696916255869698397905954902832795240404252593253922975338362032908148800408",
+    "summonerLevel": 420
+  }
+]

--- a/Program.cs
+++ b/Program.cs
@@ -6,12 +6,22 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 
+builder.Services.AddTransient<TftSeeder>();
+
+//Setup DBContext
 if (builder.Environment.IsDevelopment())
     builder.Services.AddDbContext<TftContext>(options => options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
 else
     builder.Services.AddDbContext<TftContext>(options => options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 var app = builder.Build();
+
+//Seed the DB with dummy data when provided with "/seed"
+using (var scope = app.Services.CreateScope())
+{
+    var seeder = scope.ServiceProvider.GetService<TftSeeder>();
+    seeder.Seed();
+}
 
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ else
 
 var app = builder.Build();
 
-//Seed the DB with dummy data when provided with "/seed"
+//Seed the DB with dummy data
 using (var scope = app.Services.CreateScope())
 {
     var seeder = scope.ServiceProvider.GetService<TftSeeder>();

--- a/Views/Summoner/Index.cshtml
+++ b/Views/Summoner/Index.cshtml
@@ -1,8 +1,38 @@
+@model IEnumerable<Summoner>
+
 @{
     ViewData["Title"] = "Summoner";
 }
 
 <div class="text-center">
-    <h1 class="display-4">Nyes</h1>
-    @ViewData["Test"]
+    <h1 class="display-4">Summoners</h1>
 </div>
+<table class="table">
+    <thead>
+        <th>
+            @Html.DisplayNameFor(model => model.accountId)
+        </th>
+        <th>
+            @Html.DisplayNameFor(model => model.name)
+        </th>
+        <th>
+            @Html.DisplayNameFor(model => model.summonerLevel)
+        </th>
+    </thead>
+    <tbody>
+        @foreach (var summoner in Model)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => summoner.accountId)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => summoner.name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => summoner.summonerLevel)
+                </td>
+            </tr>
+        }
+    </tbody>
+</table>

--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,3 +1,4 @@
 ﻿@using TftTracker
 @using TftTracker.Models
+@using TftTracker.Data.Entities
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/bin/Debug/net6.0/Data/summoners.json
+++ b/bin/Debug/net6.0/Data/summoners.json
@@ -1,0 +1,47 @@
+[
+    {
+    "accountId": "001",
+    "profileIconId": 1,
+    "revisionDate": 1637336253,
+    "name": "Vontell",
+    "id": "001",
+    "puuid": "223966216255869698397905954902832795240404252593253922975338362032908148800408",
+    "summonerLevel": 162
+  },
+  {
+    "accountId": "002",
+    "profileIconId": 2,
+    "revisionDate": 1637422653,
+    "name": "Noamit",
+    "id": "002",
+    "puuid": "334593073194552560377406391315206530355033163841091350809301025445228966072860",
+    "summonerLevel": 246
+  },
+  {
+    "accountId": "003",
+    "profileIconId": 3,
+    "revisionDate": 1637595453,
+    "name": "Elderhide",
+    "id": "003",
+    "puuid": "195111894475779608026284291654379250725617682730593568767939056016018336320484",
+    "summonerLevel": 77
+  },
+  {
+    "accountId": "004",
+    "profileIconId": 4,
+    "revisionDate": 1637681853,
+    "name": "Teemo Bot",
+    "id": "004",
+    "puuid": "897926350420425281935752938630402765267895217933423546578213631820283390490146",
+    "summonerLevel": 288
+  },
+  {
+    "accountId": "420",
+    "profileIconId": 420,
+    "revisionDate": 1637509420,
+    "name": "Ganjasaurus",
+    "id": "420",
+    "puuid": "420696916255869698397905954902832795240404252593253922975338362032908148800408",
+    "summonerLevel": 420
+  }
+]


### PR DESCRIPTION
Two parts to this PR. First is adding the ability to seed the DB with some dummy data. This has been added to enable the showing of said data on the /summoner page. The Summoner page now displays a table with basic information of each stored summoner record

![image](https://user-images.githubusercontent.com/38171529/143365619-7de1230c-6b1a-46d8-8938-54749d33a7e4.png)
