### PR TITLE
Add summoner search functionality

### DIFF
--- a/Api/ISummonerProcessor.cs
+++ b/Api/ISummonerProcessor.cs
@@ -2,7 +2,7 @@ using TftTracker.Data.Entities;
 
 namespace TftTracker.Api
 {
-    interface ISummonerProcessor
+    public interface ISummonerProcessor
     {
         Task<Summoner> LoadSummoner(string summonerName); 
     }

--- a/Api/Mocks/MockSummonerProcessor.cs
+++ b/Api/Mocks/MockSummonerProcessor.cs
@@ -20,9 +20,10 @@ namespace TftTracker.Api
             if (String.IsNullOrWhiteSpace(summonerName))
                 return null;
 
-            var summoners = _context.Summoners.Select(s => s).ToList();
+            var summoners = _context.Summoners.ToList();
             var summoner = new Summoner{
                 accountId = NextId(summoners, s => Int32.Parse(s.accountId)),
+                profileIconId = new Random().Next(1, 9),
                 revisionDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
                 name = summonerName,
                 id = NextId(summoners, s => Int32.Parse(s.id)),

--- a/Api/Mocks/MockSummonerProcessor.cs
+++ b/Api/Mocks/MockSummonerProcessor.cs
@@ -1,13 +1,54 @@
+using TftTracker.Data;
 using TftTracker.Data.Entities;
 
 namespace TftTracker.Api
 {
     public class MockSummonerProcessor : ISummonerProcessor
     {
-        public Task<Summoner> LoadSummoner(string summonerName)
+        private const int PuuidLength = 78;
+
+        private readonly TftContext _context;
+
+        public MockSummonerProcessor(TftContext context)
         {
-            Summoner summoner = new Summoner();
-            return Task.FromResult(summoner);
+            _context = context;
+        }
+
+
+        public async Task<Summoner> LoadSummoner(string summonerName)
+        {
+            if (String.IsNullOrWhiteSpace(summonerName))
+                return null;
+
+            var summoners = _context.Summoners.Select(s => s).ToList();
+            var summoner = new Summoner{
+                accountId = NextId(summoners, s => Int32.Parse(s.accountId)),
+                revisionDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
+                name = summonerName,
+                id = NextId(summoners, s => Int32.Parse(s.id)),
+                puuid = RandomPuuid(),
+                summonerLevel = new Random().Next(1, 999)
+            };
+
+            await _context.Summoners.AddAsync(summoner);
+            await _context.SaveChangesAsync();
+
+            return summoner;
+        }
+
+        private string NextId(List<Summoner> summoners, Func<Summoner, int> getId)
+        {
+            var maxId = summoners.Max(s => getId(s));
+            maxId++;
+            return maxId.ToString();
+        }
+
+        private string RandomPuuid()
+        {
+            const string numbers = "0123456789";
+            var random = new Random();
+            return new string(Enumerable.Repeat(numbers, PuuidLength)
+                .Select(s => s[random.Next(s.Length)]).ToArray());  
         }
     }
 }

--- a/Api/SummonerProcessor.cs
+++ b/Api/SummonerProcessor.cs
@@ -4,7 +4,7 @@ using TftTracker.Data.Entities;
 
 namespace TftTracker.Api
 {
-    public class SummonerV1Processor : ISummonerProcessor
+    public class SummonerProcessor : ISummonerProcessor
     {
         public async Task<Summoner> LoadSummoner(string summonerName)
         {

--- a/Controllers/SummonerController.cs
+++ b/Controllers/SummonerController.cs
@@ -13,21 +13,21 @@ namespace TftTracker.Controllers
             _context = context;
         }
 
-        //GET: Movies
+        //GET: Summoner
         public async Task<IActionResult> Index()
         {
            return View(await _context.Summoners.ToListAsync());
         }
 
-        // GET: Movies/Details
-        public async Task<IActionResult> Details(string id)
+        //GET: Summoner/Details/{name}
+        public async Task<IActionResult> Details(string name)
         {
-            if (id == null)
+            if (name == null)
                 return NotFound();
-
-            var summoner = await _context.Summoners.FirstOrDefaultAsync(s => s.accountId == id);
-            if (summoner == null)
-            return NotFound();
+            
+            var summoner = await _context.Summoners.FirstOrDefaultAsync(s => s.name.ToLower().Equals(name.ToLower()));
+             if (summoner == null) //This is where we will hit Riot's API if we don't find summoner locally
+                return NotFound();
 
             return View(summoner);
         }

--- a/Data/Entities/Summoner.cs
+++ b/Data/Entities/Summoner.cs
@@ -14,6 +14,8 @@ namespace TftTracker.Data.Entities
         public string name { get; set; }
         public string id { get; set; }
         public string puuid { get; set; }
+
+        [Display(Name = "Summoner Level")]
         public long summonerLevel { get; set; }
     }
 }

--- a/Data/Entities/Summoner.cs
+++ b/Data/Entities/Summoner.cs
@@ -1,10 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TftTracker.Data.Entities
 {
     public class Summoner
     {
         public string accountId { get; set; }
         public int profileIconId { get; set; }
+
+        [Display(Name = "Last Updated")]
         public long revisionDate { get; set; }
+
+        [Display(Name = "Summoner Name")]
         public string name { get; set; }
         public string id { get; set; }
         public string puuid { get; set; }

--- a/Program.cs
+++ b/Program.cs
@@ -39,6 +39,11 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapControllerRoute(
+    name: "summoner",
+    defaults: new { controller = "Summoner", action = "Details" },
+    pattern: "{controller}/{action}/{name}");
+
+app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 

--- a/Program.cs
+++ b/Program.cs
@@ -9,9 +9,9 @@ builder.Services.AddControllersWithViews();
 
 builder.Services.AddTransient<TftSeeder>();
 if (builder.Environment.IsDevelopment())
-    builder.Services.AddTransient<MockSummonerProcessor>();
+    builder.Services.AddTransient<ISummonerProcessor, MockSummonerProcessor>();
 else
-    builder.Services.AddTransient<SummonerProcessor>();
+    builder.Services.AddTransient<ISummonerProcessor, SummonerProcessor>();
 
 //Setup DBContext
 if (builder.Environment.IsDevelopment())

--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,4 @@
+using TftTracker.Api;
 using TftTracker.Data;
 using Microsoft.EntityFrameworkCore;
 
@@ -7,6 +8,10 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 
 builder.Services.AddTransient<TftSeeder>();
+if (builder.Environment.IsDevelopment())
+    builder.Services.AddTransient<MockSummonerProcessor>();
+else
+    builder.Services.AddTransient<SummonerProcessor>();
 
 //Setup DBContext
 if (builder.Environment.IsDevelopment())
@@ -37,11 +42,6 @@ app.UseStaticFiles();
 app.UseRouting();
 
 app.UseAuthorization();
-
-app.MapControllerRoute(
-    name: "summoner",
-    defaults: new { controller = "Summoner", action = "Details" },
-    pattern: "{controller}/{action}/{name}");
 
 app.MapControllerRoute(
     name: "default",

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -27,6 +27,13 @@
                         </li>
                     </ul>
                 </div>
+
+                <form asp-controller="Summoner" asp-action="Details" method="get">
+                    <p>
+                        <input type="text" name="Name" placeholder="Enter Summoner Name"/>
+                        <input type="submit" class="btn btn-success" value="Search"/>
+                    </p>
+                </form>
             </div>
         </nav>
     </header>

--- a/Views/Summoner/Index.cshtml
+++ b/Views/Summoner/Index.cshtml
@@ -34,7 +34,7 @@
                     @Html.DisplayFor(modelItem => summoner.summonerLevel)
                 </td>
                 <td>
-                    <a asp-action="Details" asp-route-id="@summoner.accountId">Details</a>
+                    <a asp-action="Details" asp-route-name="@summoner.name">Details</a>
                 </td>
             </tr>
         }

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=TftTracker.db"
   }
 }

--- a/bin/Debug/net6.0/appsettings.Development.json
+++ b/bin/Debug/net6.0/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=TftTracker.db"
   }
 }


### PR DESCRIPTION
On the front-end this adds a search bar to the global header which allows for searching of summoners by name. When a summoner is found it will display a page showing some (for now) basic information about that summoner.

Behind the scenes we are now mocking the [Riot tft summoner API](https://developer.riotgames.com/apis#tft-summoner-v1). If a summoner being searched for isn't found in the DB we "ask Riot for their information" and store it before displaying it on the front-end

![image](https://user-images.githubusercontent.com/38171529/143523857-efb38f02-af2a-4705-94a6-0d80d3853b0c.png)

![image](https://user-images.githubusercontent.com/38171529/143523868-dfb615bc-2fbc-49b1-a313-c7089ca48212.png)

