### PR TITLE
New DB tables to support the Riot Matches API

### DIFF
--- a/Api/Mocks/MockSummonerProcessor.cs
+++ b/Api/Mocks/MockSummonerProcessor.cs
@@ -22,13 +22,13 @@ namespace TftTracker.Api
 
             var summoners = _context.Summoners.ToList();
             var summoner = new Summoner{
-                accountId = NextId(summoners, s => Int32.Parse(s.accountId)),
-                profileIconId = new Random().Next(1, 9),
-                revisionDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
-                name = summonerName,
-                id = NextId(summoners, s => Int32.Parse(s.id)),
-                puuid = RandomPuuid(),
-                summonerLevel = new Random().Next(1, 999)
+                AccountId = NextId(summoners, s => Int32.Parse(s.AccountId)),
+                ProfileIconId = new Random().Next(1, 9),
+                RevisionDate = DateTimeOffset.Now.ToUnixTimeSeconds(),
+                Name = summonerName,
+                Id = NextId(summoners, s => Int32.Parse(s.Id)),
+                Puuid = RandomPuuid(),
+                SummonerLevel = new Random().Next(1, 999)
             };
 
             await _context.Summoners.AddAsync(summoner);

--- a/Controllers/SummonerController.cs
+++ b/Controllers/SummonerController.cs
@@ -28,7 +28,7 @@ namespace TftTracker.Controllers
             if (name == null)
                 return NotFound();
             
-            var summoner = await _context.Summoners.FirstOrDefaultAsync(s => s.name.ToLower().Equals(name.ToLower()));
+            var summoner = await _context.Summoners.FirstOrDefaultAsync(s => s.Name.ToLower().Equals(name.ToLower()));
             if (summoner == null)
             {
                 summoner = await _summonerProcessor.LoadSummoner(name);

--- a/Data/Entities/Match.cs
+++ b/Data/Entities/Match.cs
@@ -1,0 +1,9 @@
+namespace TftTracker.Data.Entities
+{
+    public class Match
+    {
+        public string MatchId { get; set; }
+        public MatchMetadata Metadata { get; set; }
+        public MatchInfo Info { get; set; }
+    }
+}

--- a/Data/Entities/MatchInfo.cs
+++ b/Data/Entities/MatchInfo.cs
@@ -1,0 +1,16 @@
+namespace TftTracker.Data.Entities
+{
+    public class MatchInfo
+    {
+        public int Id { get; set; }
+        public string MatchId { get; set; }
+        public Match Match { get; set; }
+        public long GameDateTime { get; set; }
+        public float GameLength { get; set; }
+        public string GameVariation { get; set; }
+        public string GameVersion { get; set; }
+        public ICollection<Participant> Participants { get; set; }
+        public int QueueId { get; set; }
+        public int TftSetNumber { get; set; }
+    }
+}

--- a/Data/Entities/MatchMetadata.cs
+++ b/Data/Entities/MatchMetadata.cs
@@ -1,0 +1,11 @@
+namespace TftTracker.Data.Entities
+{
+    public class MatchMetadata
+    {
+        public int Id { get; set; }
+        public string MatchId { get; set; }
+        public Match Match { get; set; }
+        public string DataVersion { get; set; }
+        public ICollection<Participant> Participants { get; set; }
+    }
+}

--- a/Data/Entities/Participant.cs
+++ b/Data/Entities/Participant.cs
@@ -1,0 +1,21 @@
+namespace TftTracker.Data.Entities
+{
+    public class Participant
+    {
+        public int Id { get; set; }
+        //TODO public Companian companian { get; set; }
+        public int GoldLeft { get; set; }
+        public int LastRound { get; set; }
+        public int Level { get; set; }
+        public MatchMetadata MatchMetadata { get; set; }
+        public MatchInfo MatchInfo { get; set; }
+        public int Placement { get; set; }
+        public int PlayersEliminated { get; set; }
+        public string Puuid { get; set; }
+        public Summoner Summoner { get; set; }
+        public float TimeEliminated { get; set; }
+        public int TotalDamageToPlayers { get; set; }
+        //TODO public ICollection<Trait> traits { get; set; }
+        //TODO public ICollection<Unit> units { get; set; }
+    }
+}

--- a/Data/Entities/Summoner.cs
+++ b/Data/Entities/Summoner.cs
@@ -4,18 +4,19 @@ namespace TftTracker.Data.Entities
 {
     public class Summoner
     {
-        public string accountId { get; set; }
-        public int profileIconId { get; set; }
+        public string AccountId { get; set; }
+        public int ProfileIconId { get; set; }
 
         [Display(Name = "Last Updated")]
-        public long revisionDate { get; set; }
+        public long RevisionDate { get; set; }
 
         [Display(Name = "Summoner Name")]
-        public string name { get; set; }
-        public string id { get; set; }
-        public string puuid { get; set; }
+        public string Name { get; set; }
+        public string Id { get; set; }
+        public string Puuid { get; set; }
 
         [Display(Name = "Summoner Level")]
-        public long summonerLevel { get; set; }
+        public long SummonerLevel { get; set; }
+        public ICollection<Participant> Participations { get; set; }
     }
 }

--- a/Data/Migrations/20211130033135_AddMatchEntities.Designer.cs
+++ b/Data/Migrations/20211130033135_AddMatchEntities.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TftTracker.Data;
 
@@ -10,9 +11,10 @@ using TftTracker.Data;
 namespace TftTracker.Migrations
 {
     [DbContext(typeof(TftContext))]
-    partial class TftContextModelSnapshot : ModelSnapshot
+    [Migration("20211130033135_AddMatchEntities")]
+    partial class AddMatchEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.0");

--- a/Data/Migrations/20211130033135_AddMatchEntities.cs
+++ b/Data/Migrations/20211130033135_AddMatchEntities.cs
@@ -1,0 +1,216 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TftTracker.Migrations
+{
+    public partial class AddMatchEntities : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "summonerLevel",
+                table: "Summoners",
+                newName: "SummonerLevel");
+
+            migrationBuilder.RenameColumn(
+                name: "revisionDate",
+                table: "Summoners",
+                newName: "RevisionDate");
+
+            migrationBuilder.RenameColumn(
+                name: "puuid",
+                table: "Summoners",
+                newName: "Puuid");
+
+            migrationBuilder.RenameColumn(
+                name: "profileIconId",
+                table: "Summoners",
+                newName: "ProfileIconId");
+
+            migrationBuilder.RenameColumn(
+                name: "name",
+                table: "Summoners",
+                newName: "Name");
+
+            migrationBuilder.RenameColumn(
+                name: "accountId",
+                table: "Summoners",
+                newName: "AccountId");
+
+            migrationBuilder.RenameColumn(
+                name: "id",
+                table: "Summoners",
+                newName: "Id");
+
+            migrationBuilder.CreateTable(
+                name: "Matches",
+                columns: table => new
+                {
+                    MatchId = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Matches", x => x.MatchId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MatchInfo",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    MatchId = table.Column<string>(type: "TEXT", nullable: true),
+                    GameDateTime = table.Column<long>(type: "INTEGER", nullable: false),
+                    GameLength = table.Column<float>(type: "REAL", nullable: false),
+                    GameVariation = table.Column<string>(type: "TEXT", nullable: true),
+                    GameVersion = table.Column<string>(type: "TEXT", nullable: true),
+                    QueueId = table.Column<int>(type: "INTEGER", nullable: false),
+                    TftSetNumber = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MatchInfo", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MatchInfo_Matches_MatchId",
+                        column: x => x.MatchId,
+                        principalTable: "Matches",
+                        principalColumn: "MatchId");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MatchMetadata",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    MatchId = table.Column<string>(type: "TEXT", nullable: true),
+                    DataVersion = table.Column<string>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MatchMetadata", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MatchMetadata_Matches_MatchId",
+                        column: x => x.MatchId,
+                        principalTable: "Matches",
+                        principalColumn: "MatchId");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Participants",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    GoldLeft = table.Column<int>(type: "INTEGER", nullable: false),
+                    LastRound = table.Column<int>(type: "INTEGER", nullable: false),
+                    Level = table.Column<int>(type: "INTEGER", nullable: false),
+                    MatchMetadataId = table.Column<int>(type: "INTEGER", nullable: true),
+                    MatchInfoId = table.Column<int>(type: "INTEGER", nullable: true),
+                    Placement = table.Column<int>(type: "INTEGER", nullable: false),
+                    PlayersEliminated = table.Column<int>(type: "INTEGER", nullable: false),
+                    Puuid = table.Column<string>(type: "TEXT", nullable: true),
+                    SummonerId = table.Column<string>(type: "TEXT", nullable: true),
+                    TimeEliminated = table.Column<float>(type: "REAL", nullable: false),
+                    TotalDamageToPlayers = table.Column<int>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Participants", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Participants_MatchInfo_MatchInfoId",
+                        column: x => x.MatchInfoId,
+                        principalTable: "MatchInfo",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Participants_MatchMetadata_MatchMetadataId",
+                        column: x => x.MatchMetadataId,
+                        principalTable: "MatchMetadata",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_Participants_Summoners_SummonerId",
+                        column: x => x.SummonerId,
+                        principalTable: "Summoners",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchInfo_MatchId",
+                table: "MatchInfo",
+                column: "MatchId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MatchMetadata_MatchId",
+                table: "MatchMetadata",
+                column: "MatchId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Participants_MatchInfoId",
+                table: "Participants",
+                column: "MatchInfoId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Participants_MatchMetadataId",
+                table: "Participants",
+                column: "MatchMetadataId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Participants_SummonerId",
+                table: "Participants",
+                column: "SummonerId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Participants");
+
+            migrationBuilder.DropTable(
+                name: "MatchInfo");
+
+            migrationBuilder.DropTable(
+                name: "MatchMetadata");
+
+            migrationBuilder.DropTable(
+                name: "Matches");
+
+            migrationBuilder.RenameColumn(
+                name: "SummonerLevel",
+                table: "Summoners",
+                newName: "summonerLevel");
+
+            migrationBuilder.RenameColumn(
+                name: "RevisionDate",
+                table: "Summoners",
+                newName: "revisionDate");
+
+            migrationBuilder.RenameColumn(
+                name: "Puuid",
+                table: "Summoners",
+                newName: "puuid");
+
+            migrationBuilder.RenameColumn(
+                name: "ProfileIconId",
+                table: "Summoners",
+                newName: "profileIconId");
+
+            migrationBuilder.RenameColumn(
+                name: "Name",
+                table: "Summoners",
+                newName: "name");
+
+            migrationBuilder.RenameColumn(
+                name: "AccountId",
+                table: "Summoners",
+                newName: "accountId");
+
+            migrationBuilder.RenameColumn(
+                name: "Id",
+                table: "Summoners",
+                newName: "id");
+        }
+    }
+}

--- a/Data/TftContext.cs
+++ b/Data/TftContext.cs
@@ -8,5 +8,34 @@ namespace TftTracker.Data
         public TftContext(DbContextOptions<TftContext> options) : base(options){}
         
         public DbSet<Summoner> Summoners { get; set; }
+        public DbSet<Match> Matches { get; set; }
+        public DbSet<MatchMetadata> MatchMetadata { get; set; }
+        public DbSet<MatchInfo> MatchInfo { get; set; }
+        public DbSet<Participant> Participants { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Match>()
+            .HasOne(m => m.Metadata)
+            .WithOne(m => m.Match)
+            .HasForeignKey<MatchMetadata>(m => m.MatchId);
+            
+            modelBuilder.Entity<Match>()
+            .HasOne(m => m.Info)
+            .WithOne(i => i.Match)
+            .HasForeignKey<MatchInfo>(i => i.MatchId);
+
+            modelBuilder.Entity<MatchInfo>()
+            .HasMany(i => i.Participants)
+            .WithOne(p => p.MatchInfo);
+
+            modelBuilder.Entity<MatchMetadata>()
+            .HasMany(m => m.Participants)
+            .WithOne(p => p.MatchMetadata);
+
+            modelBuilder.Entity<Summoner>()
+            .HasMany(s => s.Participations)
+            .WithOne(p => p.Summoner);
+        }
     }
 }

--- a/Views/Summoner/Details.cshtml
+++ b/Views/Summoner/Details.cshtml
@@ -11,31 +11,31 @@
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.accountId)
+            @Html.DisplayNameFor(model => model.AccountId)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.accountId)
+            @Html.DisplayFor(model => model.AccountId)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.name)
+            @Html.DisplayNameFor(model => model.Name)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.name)
+            @Html.DisplayFor(model => model.Name)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.summonerLevel)
+            @Html.DisplayNameFor(model => model.SummonerLevel)
         </dt>
         <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.summonerLevel)
+            @Html.DisplayFor(model => model.SummonerLevel)
         </dd>
         <dt class="col-sm-2">
-            @Html.DisplayNameFor(model => model.revisionDate)
+            @Html.DisplayNameFor(model => model.RevisionDate)
         </dt>
         <dd class="col-sm-10">
             @{
-                var revisionDatTime = DateTimeOffset.FromUnixTimeSeconds(Model.revisionDate);
+                var revisionDateTime = DateTimeOffset.FromUnixTimeSeconds(Model.RevisionDate);
             }
-            @Html.DisplayFor(model => revisionDatTime.Date)
+            @Html.DisplayFor(model => revisionDateTime.Date)
         </dd>
     </dl>
 </div>

--- a/Views/Summoner/Index.cshtml
+++ b/Views/Summoner/Index.cshtml
@@ -10,13 +10,13 @@
 <table class="table">
     <thead>
         <th>
-            @Html.DisplayNameFor(model => model.accountId)
+            @Html.DisplayNameFor(model => model.AccountId)
         </th>
         <th>
-            @Html.DisplayNameFor(model => model.name)
+            @Html.DisplayNameFor(model => model.Name)
         </th>
         <th>
-            @Html.DisplayNameFor(model => model.summonerLevel)
+            @Html.DisplayNameFor(model => model.SummonerLevel)
         </th>
         <th></th>
     </thead>
@@ -25,16 +25,16 @@
         {
             <tr>
                 <td>
-                    @Html.DisplayFor(modelItem => summoner.accountId)
+                    @Html.DisplayFor(modelItem => summoner.AccountId)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => summoner.name)
+                    @Html.DisplayFor(modelItem => summoner.Name)
                 </td>
                 <td>
-                    @Html.DisplayFor(modelItem => summoner.summonerLevel)
+                    @Html.DisplayFor(modelItem => summoner.SummonerLevel)
                 </td>
                 <td>
-                    <a asp-action="Details" asp-route-name="@summoner.name">Details</a>
+                    <a asp-action="Details" asp-route-name="@summoner.Name">Details</a>
                 </td>
             </tr>
         }


### PR DESCRIPTION
Adds four new tables (Match, MatchMetadata, MatchInfo, Participant) to the database to support data from Riot's TFT-MATCH-V1 API

![image](https://user-images.githubusercontent.com/38171529/143995936-6912ee4b-dcdb-44fe-88c5-94c405a5affe.png)
